### PR TITLE
Wip/methods

### DIFF
--- a/methods.json
+++ b/methods.json
@@ -4,10 +4,21 @@
     // FIXME: Returns a promise.  How to indicate useless return value?
     "returns": {}
   },
-  "sdk.getDrive(url).writable": {
+  "sdk.getDrive(url,driveOpts).writable": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       }
     },
     "required": ["url"],
@@ -16,10 +27,21 @@
       "type": "boolean"
     }
   },
-  "sdk.getDrive(url).del(path)": {
+  "sdk.getDrive(url,driveOpts).del(path)": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       },
       "path": {
         "type": "string"
@@ -28,10 +50,21 @@
     "required": ["url", "path"],
     "returns": {}
   },
-  "sdk.getDrive(url).entry(path,options)": {
+  "sdk.getDrive(url,driveOpts).entry(path,options)": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       },
       "path": {
         "type": "string"
@@ -91,10 +124,21 @@
       }
     }
   },
-  "sdk.getDrive(url).get(path,options)": {
+  "sdk.getDrive(url,driveOpts).get(path,options)": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       },
       "path": {
         "type": "string"
@@ -117,10 +161,21 @@
       "format": "base64"
     }
   },
-  "sdk.getDrive(url).list(folder,options)": {
+  "sdk.getDrive(url,driveOpts).list(folder,options)": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       },
       "folder": {
         "type": "string"
@@ -177,10 +232,21 @@
       }
     }
   },
-  "sdk.getDrive(url).mirror(out, options)": {
+  "sdk.getDrive(url,driveOpts).mirror(out, options)": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       },
       "out": {
         "type": "string"
@@ -227,20 +293,42 @@
       "format": "base64"
     }
   },
-  "sdk.getDrive(url).purge()": {
+  "sdk.getDrive(url,driveOpts).purge()": {
     "properties": {
       "url": {
         "type": "string"
       }
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
+      },
     },
     "required": ["url"],
     // FIXME: Returns a promise
     "returns": {}
   },
-  "sdk.getDrive(url).put(path,buffer,options)": {
+  "sdk.getDrive(url,driveOpts).put(path,buffer,options)": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       },
       "path": {
         "type": "string"
@@ -266,10 +354,21 @@
     // FIXME: Actually returns Batch.put()
     "returns": {}
   },
-  "sdk.getDrive(url).readdir(folder)": {
+  "sdk.getDrive(url,driveOpts).readdir(folder)": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       },
       "folder": {
         "type": "string",
@@ -284,10 +383,21 @@
       }
     }
   },
-  "sdk.getDrive(url).url": {
+  "sdk.getDrive(url,driveOpts).url": {
     "properties": {
       "url": {
         "type": "string"
+      },
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
       }
     },
     "required": ["url"],
@@ -295,11 +405,22 @@
       "type": "string"
     }
   },
-  "sdk.getDrive(url).version": {
+  "sdk.getDrive(url,driveOpts).version": {
     "properties": {
       "url": {
         "type": "string"
       }
+      "driveOpts": {
+        "type": "object",
+        "properties": {
+          "autoJoin": {
+            "type": "boolean"
+          },
+          "sparse": {
+            "type": "boolean"
+          }
+        }
+      },
     },
     "required": ["url"],
     "returns": {

--- a/methods.json
+++ b/methods.json
@@ -42,6 +42,31 @@
       "format": "base64"
     }
   },
+  "sdk.getDrive(url).createWriteStream(path,options)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "options": {
+        "type": "object",
+        "properties": {
+          "executable": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    },
+    "required": ["url", "path"],
+    // FIXME: Returns the write stream.  Not useful when serialized?
+    "returns": {}
+  },
   "sdk.getDrive(url).del(path)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -301,6 +301,9 @@
         "type": "string"
       }
     },
-    "required": ["url"]
+    "required": ["url"],
+    "returns": {
+      "type": "number"
+    }
   }
 }

--- a/methods.json
+++ b/methods.json
@@ -4,31 +4,6 @@
     // FIXME: Returns a promise.  How to indicate useless return value?
     "returns": {}
   },
-  "sdk.getDrive(url).createWriteStream(path,options)": {
-    "properties": {
-      "url": {
-        "type": "string"
-      },
-      "path": {
-        "type": "string"
-      },
-      "options": {
-        "type": "object",
-        "properties": {
-          "executable": {
-            "type": "boolean"
-          },
-          "metadata": {
-            "type": "object",
-            "properties": {}
-          }
-        }
-      }
-    },
-    "required": ["url", "path"],
-    // FIXME: Returns the write stream.  Not useful when serialized?
-    "returns": {}
-  },
   "sdk.getDrive(url).writable": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -253,7 +253,9 @@
         "properties": {}
       }
     },
-    "required": ["url", "out"]
+    "required": ["url", "out"],
+    // FIXME: Returns a MirrorDrive, which is not useful serialized.
+    "returns": {}
   },
   "sdk.peers": {
     "properties": {},

--- a/methods.json
+++ b/methods.json
@@ -1,4 +1,67 @@
 {
+  "sdk.getDrive(url).entry(path,options)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "options": {
+        "type": "object",
+        "properties": {
+          "follow": {
+            "type": "boolean"
+          },
+          "wait": {
+            "type": "boolean"
+          },
+          "timeout": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "required": ["url", "path"],
+    "returns": {
+      "type": "object",
+      "properties": {
+        "seq": "number",
+        "key": "string",
+        "value": {
+          "type": "object",
+          "properties": {
+            "executable": {
+              "type": "boolean"
+            },
+            "linkname": {
+              // FIXME: "linkname" may also be "null"
+              "type": "string"
+            },
+            "blob": {
+              "type": "object",
+              "properties": {
+                "blockOffset": {
+                  "type": "number"
+                },
+                "blockLength": {
+                  "type": "number"
+                },
+                "byteOffset": {
+                  "type": "number"
+                },
+                "byteLength": {
+                  "type": "number"
+                }
+              }
+            },
+            // FIXME: metadata can be anything?
+            "metadata": {}
+          }
+        }
+      }
+    }
+  },
   "sdk.getDrive(url).get(path,options)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -140,6 +140,17 @@
     },
     "required": ["url"]
   },
+  "sdk.getDrive(url).url": {
+    "properties": {
+      "url": {
+        "type": "string"
+      }
+    },
+    "required": ["url"],
+    "returns": {
+      "type": "string"
+    }
+  },
   "sdk.getDrive(url).version": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -347,14 +347,6 @@
       }
     }
   },
-  "sdk.getDrive(url).ready()": {
-    "properties": {
-      "url": {
-        "type": "string"
-      }
-    },
-    "required": ["url"]
-  },
   "sdk.getDrive(url).url": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -103,6 +103,16 @@
     },
     "required": ["url", "out"]
   },
+  "sdk.getDrive(url).purge()": {
+    "properties": {
+      "url": {
+        "type": "string"
+      }
+    },
+    "required": ["url"],
+    // FIXME: Returns a promise
+    "returns": {}
+  },
   "sdk.getDrive(url).put(path,buffer,options)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -1,4 +1,30 @@
 {
+  "sdk.getDrive(url).get(path,options)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "options": {
+        "type": "object",
+        "properties": {
+          "wait": {
+            "type": "boolean"
+          },
+          "timeout": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "required": ["url", "path"],
+    "returns": {
+      "type": "string",
+      "format": "base64"
+    }
+  },
   "sdk.getDrive(url).mirror(out, options)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -103,6 +103,35 @@
     },
     "required": ["url", "out"]
   },
+  "sdk.getDrive(url).put(path,buffer,options)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "buffer": {
+        "type": "string",
+        "format": "base64"
+      },
+      "options": {
+        "type": "object",
+        "properties": {
+          "executable": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    },
+    "required": ["url", "path", "buffer"],
+    // FIXME: Actually returns Batch.put()
+    "returns": {}
+  },
   "sdk.getDrive(url).version": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -192,6 +192,24 @@
     // FIXME: Actually returns Batch.put()
     "returns": {}
   },
+  "sdk.getDrive(url).readdir(folder)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "folder": {
+        "type": "string",
+        "format": "base64"
+      }
+    },
+    "required": ["url", "folder"],
+    "returns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
   "sdk.getDrive(url).ready()": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -105,6 +105,66 @@
       "format": "base64"
     }
   },
+  "sdk.getDrive(url).list(folder,options)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "folder": {
+        "type": "string"
+      },
+      "options": {
+        "type": "object",
+        "properties": {
+          "recursive": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "required": ["url", "folder"],
+    "returns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "seq": "number",
+          "key": "string",
+          "value": {
+            "type": "object",
+            "properties": {
+              "executable": {
+                "type": "boolean"
+              },
+              "linkname": {
+                // FIXME: "linkname" may also be "null"
+                "type": "string"
+              },
+              "blob": {
+                "type": "object",
+                "properties": {
+                  "blockOffset": {
+                    "type": "number"
+                  },
+                  "blockLength": {
+                    "type": "number"
+                  },
+                  "byteOffset": {
+                    "type": "number"
+                  },
+                  "byteLength": {
+                    "type": "number"
+                  }
+                }
+              },
+              // FIXME: metadata can be anything?
+              "metadata": {}
+            }
+          }
+        }
+      }
+    }
+  },
   "sdk.getDrive(url).mirror(out, options)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -4,6 +4,44 @@
     // FIXME: Returns a promise.  How to indicate useless return value?
     "returns": {}
   },
+  "sdk.getDrive(url).createReadStream(path, options)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "options": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "number"
+          },
+          "end": {
+            "type": "number"
+          },
+          "length": {
+            "type": "number"
+          },
+          "wait": {
+            "type": "boolean"
+          },
+          "timeout": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "required": ["url", "path"],
+    "returns": {
+      // TODO: Returns a stream which should be converted to a base64
+      // string, not an array, right?  May the "type" of "returns" be a
+      // "string"?  Or must it be an "object" or an "array"?
+      "type": "string",
+      "format": "base64"
+    }
+  },
   "sdk.getDrive(url).del(path)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -132,6 +132,14 @@
     // FIXME: Actually returns Batch.put()
     "returns": {}
   },
+  "sdk.getDrive(url).ready()": {
+    "properties": {
+      "url": {
+        "type": "string"
+      }
+    },
+    "required": ["url"]
+  },
   "sdk.getDrive(url).version": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -115,6 +115,32 @@
     },
     "required": ["url", "out"]
   },
+  "sdk.peers": {
+    "properties": {},
+    "returns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "publicKey": {
+            "type": "string",
+            "format": "base64"
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              // FIXME: According to the docs, topics are base32
+              "format": "base32"
+            }
+          },
+          "prioritized": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  },
   "sdk.getDrive(url).purge()": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -1,14 +1,23 @@
 {
-	"sdk.getDrive(url).version": {
-		"properties": {
-			"url" : {"type": "string"}
-		}
-	},
-	"sdk.getDrive(url).mirror(out,options)": {
-		"properties": {
-			"url": {"type": "string"},
-			"out": {"type": "string"},
-			"options": {"type": "object", "properties": {}}
-		}
-	}
+  "sdk.getDrive(url).mirror(out, options)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "out": {
+        "type": "string"
+      },
+      "options": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  },
+  "sdk.getDrive(url).version": {
+    "properties": {
+      "url": {
+        "type": "string"
+      }
+    }
+  }
 }

--- a/methods.json
+++ b/methods.json
@@ -1,8 +1,6 @@
 {
   "sdk.close()": {
     "properties": {},
-    // FIXME: Returns a promise.  How to indicate useless return value?
-    "returns": {}
   },
   "sdk.getDrive(url,driveOpts).writable": {
     "properties": {
@@ -23,7 +21,6 @@
     },
     "required": ["url"],
     "returns": {
-      // FIXME: Can "returns" be a "boolean"?
       "type": "boolean"
     }
   },
@@ -97,7 +94,6 @@
               "type": "boolean"
             },
             "linkname": {
-              // FIXME: "linkname" may also be "null"
               "type": "string"
             },
             "blob": {
@@ -117,8 +113,9 @@
                 }
               }
             },
-            // FIXME: metadata can be anything?
-            "metadata": {}
+            "metadata": {
+              "type": "object"
+            }
           }
         }
       }
@@ -275,8 +272,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              // FIXME: According to the docs, topics are base32
-              "format": "base32"
+              "format": "base64"
             }
           },
           "prioritized": {
@@ -311,8 +307,6 @@
       },
     },
     "required": ["url"],
-    // FIXME: Returns a promise
-    "returns": {}
   },
   "sdk.getDrive(url,driveOpts).put(path,buffer,options)": {
     "properties": {

--- a/methods.json
+++ b/methods.json
@@ -4,44 +4,6 @@
     // FIXME: Returns a promise.  How to indicate useless return value?
     "returns": {}
   },
-  "sdk.getDrive(url).createReadStream(path, options)": {
-    "properties": {
-      "url": {
-        "type": "string"
-      },
-      "path": {
-        "type": "string"
-      },
-      "options": {
-        "type": "object",
-        "properties": {
-          "start": {
-            "type": "number"
-          },
-          "end": {
-            "type": "number"
-          },
-          "length": {
-            "type": "number"
-          },
-          "wait": {
-            "type": "boolean"
-          },
-          "timeout": {
-            "type": "number"
-          }
-        }
-      }
-    },
-    "required": ["url", "path"],
-    "returns": {
-      // TODO: Returns a stream which should be converted to a base64
-      // string, not an array, right?  May the "type" of "returns" be a
-      // "string"?  Or must it be an "object" or an "array"?
-      "type": "string",
-      "format": "base64"
-    }
-  },
   "sdk.getDrive(url).createWriteStream(path,options)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -67,6 +67,18 @@
     // FIXME: Returns the write stream.  Not useful when serialized?
     "returns": {}
   },
+  "sdk.getDrive(url).writable": {
+    "properties": {
+      "url": {
+        "type": "string"
+      }
+    },
+    "required": ["url"],
+    "returns": {
+      // FIXME: Can "returns" be a "boolean"?
+      "type": "boolean"
+    }
+  },
   "sdk.getDrive(url).del(path)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -254,8 +254,18 @@
       }
     },
     "required": ["url", "out"],
-    // FIXME: Returns a MirrorDrive, which is not useful serialized.
-    "returns": {}
+    "returns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "op": "string",
+          "key": "string",
+          "bytesRemoved": "number",
+          "bytesAdded": "number"
+        }
+      }
+    }
   },
   "sdk.peers": {
     "properties": {},

--- a/methods.json
+++ b/methods.json
@@ -11,13 +11,15 @@
         "type": "object",
         "properties": {}
       }
-    }
+    },
+    "required": ["url", "out"]
   },
   "sdk.getDrive(url).version": {
     "properties": {
       "url": {
         "type": "string"
       }
-    }
+    },
+    "required": ["url"]
   }
 }

--- a/methods.json
+++ b/methods.json
@@ -141,6 +141,13 @@
       }
     }
   },
+  "sdk.publicKey": {
+    "properties": {},
+    "returns": {
+      "type": "string",
+      "format": "base64"
+    }
+  },
   "sdk.getDrive(url).purge()": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -1,4 +1,16 @@
 {
+  "sdk.getDrive(url).del(path)": {
+    "properties": {
+      "url": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      }
+    },
+    "required": ["url", "path"],
+    "returns": {}
+  },
   "sdk.getDrive(url).entry(path,options)": {
     "properties": {
       "url": {

--- a/methods.json
+++ b/methods.json
@@ -1,4 +1,9 @@
 {
+  "sdk.close()": {
+    "properties": {},
+    // FIXME: Returns a promise.  How to indicate useless return value?
+    "returns": {}
+  },
   "sdk.getDrive(url).del(path)": {
     "properties": {
       "url": {


### PR DESCRIPTION
I'll keep pushing to this branch, but I figured I'd submit the PR since I have questions:

The options argument to `drive.mirror` has a `properties` key whose value is currently specified in `methods.json` as an empty object:

```
"options": {
  "type": "object",
  "properties": {}
}
```
Should we specify the types of those [options](https://github.com/holepunchto/mirror-drive#const-mirror--new-mirrordrivesrc-dst-options)?

What about the  whose value are functions? Just "function" or do we want to specify a function signature?

```
filter: (key) => true,
metadataEquals: (srcMetadata, dstMetadata) => { ... }
```

Should we differentiate required and optional arguments?

Should the type of buffers be `string`?